### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,7 @@ parts:
     configflags: ["-DUNIX_STRUCTURE=0", "-DCMAKE_INSTALL_PREFIX=/usr"]
     source: 
       - on amd64: https://github.com/obsproject/obs-studio.git
+      - on i386: https://github.com/obsproject/obs-studio.git
       - on armhf: fail
       - on arm64: fail
     override-pull: |


### PR DESCRIPTION
Fix i386 builds. I had missed off the source line for i386 builds, like a silly rabbit.