### PR TITLE
Add gtk-common-themes plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -161,3 +161,16 @@ parts:
         - libnuma1
       - on arm64: 
         - libnuma1
+plugs:
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes


### PR DESCRIPTION
As per discussion with desktop team, I'm adding plugs stanzas to re-use themes from the gtk-common-themes snap.