### PR TITLE
Drop unnecessary code

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,14 +40,11 @@ parts:
     source: https://github.com/obsproject/obs-studio.git
     override-pull: |
       snapcraftctl pull
-      last_committed_tag="$(git -C ../src tag | sort -V | tail -n 1)"
+      last_committed_tag="$(git tag | sort -V | tail -n 1)"
       last_released_tag="$(snap info obs-studio | awk '$1 == "beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
       # beta, build that tag instead of master.
       if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
-        git fetch
-        git checkout "${last_committed_tag}"
-        cd ../src
         git checkout "${last_committed_tag}"
       fi
       snapcraftctl set-version "$(git describe --tags)"


### PR DESCRIPTION
The working directory in the `override-pull` scriptlet is by default SNAPCRAFT_PART_SRC(parts/_part_name_/src), thus there's no reason to change the working directory to `../src` as it is the same.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>