### PR TITLE
Migrate configuration to user's real home

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -40,6 +40,27 @@ fi
 
 echo $PATH
 
+REALHOME=`getent passwd $UID | cut -d ':' -f 6`
+if [ -d "$XDG_CONFIG_HOME/obs-studio" ]; then
+  if [ -e "$REALHOME/.config/obs-studio" ]; then
+    echo "Cannot migrate your configuration files to $REALHOME/config/obs-studio."
+    echo "Your OBS configuration is stored in $XDG_CONFIG_HOME/obs-studio"
+    echo "Please migrate and merge these files with $REALHOME/config/obs-studio,"
+    echo "and then delete $XDG_CONFIG_HOME/obs-studio..."
+  else
+    echo "Migrating OBS configuration files from $XDG_CONFIG_HOME/obs-studio"
+    echo "to $REALHOME/.config/obs-studio..."
+    mv "$XDG_CONFIG_HOME/obs-studio" "$REALHOME/.config/obs-studio"
+    ln -s "$REALHOME/.config/obs-studio" "$XDG_CONFIG_HOME/obs-studio"
+    echo "DONE. You may now find your configuration in $REALHOME/.config/obs-studio."
+  fi
+else
+  if [ ! -e "$XDG_CONFIG_HOME/obs-studio" ]; then
+    ln -s "$REALHOME/.config/obs-studio" "$XDG_CONFIG_HOME/obs-studio"
+  fi
+  echo "Your OBS configuration files are stored in $REALHOME/.config/obs-studio."
+fi
+
 cd $SNAP/usr/bin/$OBS
 
 exec ./obs "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,10 +15,10 @@ architectures:
   - build-on: i386
   
 # We should migrate to using the official folder for obs-studio config  
-#plugs:
-#  obs-config-dir:
-#    interface: personal-files
-#    write: [$HOME/.config/obs-studio]
+plugs:
+  obs-config-dir:
+    interface: personal-files
+    write: [$HOME/.config/obs-studio]
 
 apps:
   ffmpeg:
@@ -79,7 +79,8 @@ apps:
       - wayland
       - x11
   obs-studio:
-    command: desktop-launch $SNAP/bin/launcher
+    command-chain: [bin/desktop-launch]
+    command: bin/launcher
     environment:
       # Tell libGL where to find the drivers
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri
@@ -90,6 +91,7 @@ apps:
       # Ref.: https://bugs.launchpad.net/snappy/+bug/1588192
       LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-egl:$LIBGL_DRIVERS_PATH:/var/lib/snapd/lib/gl
     plugs:
+      - obs-config-dir
       - network
       - network-bind
       - desktop


### PR DESCRIPTION
Add personal-files plug (will need to request auto connecting from the forum)
Add logic to migrate existing configuration to new location; will not migrate if there is a file or directory at the new location.

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>