### PR TITLE
Allow plugins to load external libs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,7 +96,7 @@ apps:
       # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH
       # Without that OpenGL using apps do not work with the nVidia drivers.
       # Ref.: https://bugs.launchpad.net/snappy/+bug/1588192
-      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-egl:$LIBGL_DRIVERS_PATH:/var/lib/snapd/lib/gl
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-egl:$LIBGL_DRIVERS_PATH:/var/lib/snapd/lib/gl:$SNAP_USER_DATA/.config/obs-studio/plugins/libs
     plugs:
       - browser-support
       - network


### PR DESCRIPTION
This addresses #20 where plugins that need external library files loaded other than the plugin file itself.

With this change I was able to add a functioning input overlay (https://obsproject.com/forum/resources/input-overlay.552/) by compiling and placing the required libraries: **libXt** (installed with apt and copied in) and **libuiohook** (compiled https://github.com/kwhat/libuiohook and copied in).

I made the folder be `$SNAP_USER_DATA/.config/obs-studio/plugins/libs` since the plugin folder where you drop plugins is `$SNAP_USER_DATA/.config/obs-studio/plugins/<plugin name>` and thought the path for the libs to be fitting, and simple.

I did not find where to place a notice about the lib folder's location, it would be difficult to find it without one, hidden in the snapcraft.yaml file.