### PR TITLE
Migrate to using UNIX_STRUCTURE

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@
 ## Install
 
     sudo snap install obs-studio
-    snap connect obs-studio:joystick
+    sudo snap connect obs-studio:audio-record
+    sudo snap connect obs-studio:camera
+    sudo snap connect obs-studio:jack1
+    sudo snap connect obs-studio:joystick
+    sudo snap connect obs-studio:removable-media
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/obs-studio)
 

--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -2,19 +2,14 @@
 
 if [ "${SNAP_ARCH}" == "amd64" ]; then
   ARCH="x86_64-linux-gnu"
-  OBS="64bit"
 elif [ "${SNAP_ARCH}" == "armhf" ]; then
   ARCH="arm-linux-gnueabihf"
-  OBS="32bit"
 elif [ "${SNAP_ARCH}" == "arm64" ]; then
   ARCH="aarch64-linux-gnu"
-  OBS="64bit"
 elif [ "${SNAP_ARCH}" == "ppc64el" ]; then
   ARCH="powerpc64le-linux-gnu"
-  OBS="64bit"
 else
   ARCH="${SNAP_ARCH}-linux-gnu"
-  OBS="32bit"
 fi
 
 # Make PulseAudio socket available inside the snap-specific $XDG_RUNTIME_DIR
@@ -32,5 +27,4 @@ else
   export VDPAU_DRIVER_PATH="/usr/lib/${ARCH}/vdpau/"
 fi
 
-cd "${SNAP}/usr/bin/${OBS}"
-exec ./obs "${@}"
+exec "${SNAP}/usr/bin/obs" "${@}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -305,6 +305,7 @@ parts:
         -DCMAKE_CXX_COMPILER=g++-8 \
         -DCMAKE_C_COMPILER=gcc-8 \
         -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
         ${SNAPCRAFT_PART_SRC}
       make
     organize:
@@ -324,6 +325,7 @@ parts:
       - -DCMAKE_C_COMPILER=gcc-8
       - -DCMAKE_CXX_COMPILER=g++-8
       - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
       - -DUNIX_STRUCTURE=1
       - -DDISABLE_UPDATE_MODULE=TRUE
       - -DBUILD_BROWSER=ON
@@ -595,6 +597,7 @@ parts:
       - -DCMAKE_C_COMPILER=gcc-8
       - -DCMAKE_CXX_COMPILER=g++-8
       - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
       - -DLIBOBS_INCLUDE_DIR=$SNAPCRAFT_STAGE/usr/include/obs/
     build-packages:
       - libasio-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -362,6 +362,10 @@ parts:
         rm ${SNAPCRAFT_PART_SRC}/cef.tar.bz2
       fi
 
+      ####
+      #  The following plugins are all intended to be built in tree
+      ####
+
       # SceneSwitcher - https://github.com/WarmUpTill/SceneSwitcher
       cd ${SNAPCRAFT_PART_SRC}/UI/frontend-plugins/
       git clone --recursive https://github.com/WarmUpTill/SceneSwitcher.git --branch 1.5

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -534,23 +534,19 @@ parts:
   obs-v4l2sink:
     plugin: cmake
     after: [ obs ]
-    #source: https://github.com/CatxFish/obs-v4l2sink.git
-    # Using my fork for now as it rolls up various fixes missing from upstream.
-    source: https://github.com/flexiondotorg/obs-v4l2sink.git
-    configflags: ["-DCMAKE_INSTALL_PREFIX=/usr", "-DLIBOBS_LIB=$SNAPCRAFT_STAGE/usr/lib/$SNAPCRAFT_ARCH_TRIPLET", "-DCMAKE_CXX_COMPILER=g++-8", "-DCMAKE_C_COMPILER=gcc-8"]
+    source: https://github.com/CatxFish/obs-v4l2sink.git
     override-build: |
-      # The build system for this plugin is slightly broken.
-      # The initial cmake to makes the libs discoverable by `snapcraftctl build`
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DLIBOBS_LIB=${SNAPCRAFT_STAGE}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET} -DCMAKE_CXX_COMPILER=g++-8 -DCMAKE_C_COMPILER=gcc-8 ${SNAPCRAFT_PART_SRC} 2>/dev/null || true
-      snapcraftctl build
-    override-prime: |
-      if echo __SIZEOF_POINTER__ | cpp -E - - | grep '^8$' >/dev/null; then
-        cp ${SNAPCRAFT_PART_INSTALL}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/obs-plugins/v4l2sink.so ${SNAPCRAFT_PRIME}/usr/obs-plugins/64bit/
-      else
-        cp ${SNAPCRAFT_PART_INSTALL}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/obs-plugins/v4l2sink.so ${SNAPCRAFT_PRIME}/usr/obs-plugins/32bit/
-      fi
-      mkdir -p ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/v4l2sink/locale
-      mv -v ${SNAPCRAFT_PART_INSTALL}/usr/share/obs/obs-plugins/v4l2sink/locale/*.ini ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/v4l2sink/locale/
+      set -x
+      cd $SNAPCRAFT_PART_SRC
+      cmake \
+        -DCMAKE_C_COMPILER=gcc-8 \
+        -DCMAKE_CXX_COMPILER=g++-8 \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLIBOBS_INCLUDE_DIR=$SNAPCRAFT_STAGE/usr/include/obs/
+        $SNAPCRAFT_PART_SRC 2>/dev/null || true
+      make
+      make install
 
   obs-transition-matrix:
     plugin: cmake

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -474,7 +474,6 @@ parts:
       # Required by Spectralizer
       - libfftw3-dev
       # Required by StreamFX
-      #- libqt5x11extras5-dev
       - ninja-build
     stage-packages:
       # Based on https://obsproject.com/wiki/install-instructions#debian-based-build-directions
@@ -520,8 +519,6 @@ parts:
       - libxtst6
       # Required by Spectralizer
       - libfftw3-3
-      # Required by Input Overlay
-      - libxt6
 
   obs-v4l2sink:
     plugin: cmake

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,20 @@ plugs:
     target: $SNAP/data-dir/sounds
     default-provider: gtk-common-themes
 
+layout:
+  /usr/lib/obs-plugins:
+    bind: $SNAP/usr/lib/obs-plugins
+  /usr/lib/obs-scripting:
+    bind: $SNAP/usr/lib/obs-scripting
+  /usr/local/lib:
+    bind: $SNAP/usr/local/lib
+  /usr/share/alsa:
+    bind: $SNAP/usr/share/alsa
+  /usr/share/obs:
+    bind: $SNAP/usr/share/obs
+  /usr/share/X11:
+    bind: $SNAP/usr/share/X11
+
 apps:
   obs-studio:
     command: desktop-launch $SNAP/bin/launcher
@@ -310,6 +324,7 @@ parts:
       - -DCMAKE_C_COMPILER=gcc-8
       - -DCMAKE_CXX_COMPILER=g++-8
       - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DUNIX_STRUCTURE=1
       - -DDISABLE_UPDATE_MODULE=TRUE
       - -DBUILD_BROWSER=ON
       - -DCEF_ROOT_DIR=$SNAPCRAFT_PART_SRC/cef_binary
@@ -401,18 +416,16 @@ parts:
 
     override-build: |
       # obs-frontend-api.h is required for plugins to build
-      cp -v ${SNAPCRAFT_PART_SRC}/UI/obs-frontend-api/obs-frontend-api.h ${SNAPCRAFT_STAGE}/usr/include/
+      mkdir -p ${SNAPCRAFT_STAGE}/usr/include/obs || true
+      cp -v ${SNAPCRAFT_PART_SRC}/UI/obs-frontend-api/*.h ${SNAPCRAFT_STAGE}/usr/include/obs/
       # ObsPluginHelpers.cmake
-      mkdir -p ${SNAPCRAFT_STAGE}/usr/cmake/external
-      cp -v ${SNAPCRAFT_PART_SRC}/cmake/external/ObsPluginHelpers.cmake ${SNAPCRAFT_STAGE}/usr/cmake/external/ObsPluginHelpers.cmake
+      mkdir -p ${SNAPCRAFT_STAGE}/usr/include/cmake/external || true
+      cp -v ${SNAPCRAFT_PART_SRC}/cmake/external/*.cmake ${SNAPCRAFT_STAGE}/usr/include/cmake/external/
       snapcraftctl build
       # Fix some missing theme assets
-      cp ${SNAPCRAFT_PART_SRC}/UI/data/themes/Dark/close.svg ${SNAPCRAFT_PART_INSTALL}/usr/data/obs-studio/themes/Dark/Close.svg
-      cp ${SNAPCRAFT_PART_SRC}/UI/data/themes/Dark/popout.svg ${SNAPCRAFT_PART_INSTALL}/usr/data/obs-studio/themes/Dark/Popout.svg
+      cp ${SNAPCRAFT_PART_SRC}/UI/data/themes/Dark/close.svg ${SNAPCRAFT_PART_INSTALL}/usr/share/obs/obs-studio/themes/Dark/Close.svg
+      cp ${SNAPCRAFT_PART_SRC}/UI/data/themes/Dark/popout.svg ${SNAPCRAFT_PART_INSTALL}/usr/share/obs/obs-studio/themes/Dark/Popout.svg
 
-    organize:
-      usr/bin/*bit/*.so: usr/lib/$SNAPCRAFT_ARCH_TRIPLET/
-      usr/bin/*bit/lib*.0: usr/lib/$SNAPCRAFT_ARCH_TRIPLET/
     build-packages:
       # Based on https://obsproject.com/wiki/install-instructions#debian-based-build-directions
       - bzip2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -390,9 +390,8 @@ parts:
       # Replay Source - https://github.com/exeldro/obs-replay-source
       cd ${SNAPCRAFT_PART_SRC}/plugins/
       git clone --recursive https://github.com/exeldro/obs-replay-source.git replay-source --branch 1.5.4
+      sed -i 's/install_obs_plugin_with_data(replay-source data)/install_obs_plugin(replay-source)/' replay-source/CMakeLists.txt
       echo "add_subdirectory(replay-source)" >> CMakeLists.txt
-      cd replay-source
-      sed -i 's/install_obs_plugin_with_data(replay-source data)/install_obs_plugin(replay-source)/' CMakeLists.txt
 
       # Spectralizer - https://github.com/univrsal/spectralizer
       cd ${SNAPCRAFT_PART_SRC}/plugins/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,14 +72,24 @@ parts:
   sem-open-preload:
     source: https://github.com/sergiusens/sem-open-preload.git
     plugin: make
+    make-parameters:
+      - CC=gcc-8
+      - CXX=g++-8
+    build-packages:
+      - gcc-8
+      - g++-8
 
   desktop-qt5:
     build-packages:
+      - gcc-8
+      - g++-8
       - qtbase5-dev
       - dpkg-dev
-    make-parameters:
-      - FLAVOR=qt5
     plugin: make
+    make-parameters:
+      - CC=gcc-8
+      - CXX=g++-8
+      - FLAVOR=qt5
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
     source-subdir: qt
     stage-packages:
@@ -91,11 +101,15 @@ parts:
 
   nv-codec-headers:
     plugin: make
+    make-parameters:
+      - CC=gcc-8
+      - CXX=g++-8
+      - PREFIX=/usr
     source: https://github.com/FFmpeg/nv-codec-headers.git
     source-tag: 'n9.1.23.1'
-    override-build: |
-      make install PREFIX=/usr
     build-packages:
+      - gcc-8
+      - g++-8
       - pkg-config
 
   ffmpeg:
@@ -105,6 +119,8 @@ parts:
     source-branch: release/4.2
     source-depth: 1
     build-packages:
+      - gcc-8
+      - g++-8
       - libass-dev
       - libbz2-dev
       - libdrm-dev
@@ -191,6 +207,8 @@ parts:
         - i965-va-driver
         - libcrystalhd3
     configflags:
+      - --cc=gcc-8
+      - --cxx=g++-8
       - --prefix=/usr
       - --disable-debug
       - --disable-doc
@@ -244,16 +262,36 @@ parts:
   libuiohook:
     plugin: autotools
     configflags:
+      - CC=gcc-8
+      - CCX=g++-8
       - --prefix=/usr
     source: https://github.com/kwhat/libuiohook.git
     source-tag: '1.0.3'
-  
+    build-packages:
+      - gcc-8
+      - g++-8
+      - libxinerama-dev
+      - libxt-dev
+      - libxtst-dev
+      - pkg-config
+    stage-packages:
+      - libxinerama1
+      - libxt6
+      - libxtst6
+
   netlib:
     plugin: cmake
     source: https://github.com/univrsal/netlib.git
     source-tag: 'v0.2'
+    build-packages:
+      - gcc-8
+      - g++-8
     override-build: |
-      cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_CXX_COMPILER=g++-8 -DCMAKE_C_COMPILER=gcc-8 ${SNAPCRAFT_PART_SRC}
+      cmake \
+        -DCMAKE_CXX_COMPILER=g++-8 \
+        -DCMAKE_C_COMPILER=gcc-8 \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        ${SNAPCRAFT_PART_SRC}
       make
     organize:
       libnetlib.so: usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libnetlib.so
@@ -268,7 +306,13 @@ parts:
       # Required for input-overlay
       - libuiohook
       - netlib
-    configflags: ["-DUNIX_STRUCTURE=0", "-DDISABLE_UPDATE_MODULE=TRUE", "-DCMAKE_INSTALL_PREFIX=/usr", "-DBUILD_BROWSER=ON", "-DCEF_ROOT_DIR=$SNAPCRAFT_PART_SRC/cef_binary", "-DCMAKE_CXX_COMPILER=g++-8", "-DCMAKE_C_COMPILER=gcc-8"]
+    configflags:
+      - -DCMAKE_C_COMPILER=gcc-8
+      - -DCMAKE_CXX_COMPILER=g++-8
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DDISABLE_UPDATE_MODULE=TRUE
+      - -DBUILD_BROWSER=ON
+      - -DCEF_ROOT_DIR=$SNAPCRAFT_PART_SRC/cef_binary
     source: https://github.com/obsproject/obs-studio.git
     override-pull: |
       snapcraftctl pull

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -566,16 +566,20 @@ parts:
     after: [ obs ]
     source: https://github.com/univrsal/dvds3.git
     source-tag: 'independent-build'
-    configflags: ["-DCMAKE_INSTALL_PREFIX=/usr", "-DLIBOBS_LIB=$SNAPCRAFT_STAGE/usr/lib/$SNAPCRAFT_ARCH_TRIPLET", "-DCMAKE_CXX_COMPILER=g++-8", "-DCMAKE_C_COMPILER=gcc-8"]
-    override-prime: |
-      if echo __SIZEOF_POINTER__ | cpp -E - - | grep '^8$' >/dev/null; then
-        cp ${SNAPCRAFT_PART_INSTALL}/root/.config/obs-studio/plugins/dvd-screensaver/bin/64bit/dvd-screensaver.so ${SNAPCRAFT_PRIME}/usr/obs-plugins/64bit/
-      else
-        cp ${SNAPCRAFT_PART_INSTALL}/root/.config/obs-studio/plugins/dvd-screensaver/bin/32bit/dvd-screensaver.so ${SNAPCRAFT_PRIME}/usr/obs-plugins/32bit/
-      fi
-      mkdir -p ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/dvd-screensaver/locale
-      mv -v ${SNAPCRAFT_PART_INSTALL}/root/.config/obs-studio/plugins/dvd-screensaver/data/locale/*.ini ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/dvd-screensaver/locale/ || true
-      cp -v ${SNAPCRAFT_PART_SRC}/data/dvd.png ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/dvd-screensaver/
+    configflags:
+      - -DCMAKE_C_COMPILER=gcc-8
+      - -DCMAKE_CXX_COMPILER=g++-8
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+    override-build: |
+      snapcraftctl build
+      mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/share/obs/obs-plugins/dvd-screensaver/ || true
+      cp -v ${SNAPCRAFT_PART_SRC}/data/dvd.png ${SNAPCRAFT_PART_INSTALL}/usr/share/obs/obs-plugins/dvd-screensaver/
+    organize:
+      root/.config/obs-studio/plugins/dvd-screensaver/bin/*bit/dvd-screensaver.so: usr/lib/obs-plugins/
+      root/.config/obs-studio/plugins/dvd-screensaver/data/locale/*.ini: usr/share/obs/obs-plugins/dvd-screensaver/locale/
+    prime:
+      - -root
 
   obs-vintage-filter:
     plugin: cmake

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -394,11 +394,6 @@ parts:
       cd replay-source
       sed -i 's/install_obs_plugin_with_data(replay-source data)/install_obs_plugin(replay-source)/' CMakeLists.txt
 
-      # Websocket - https://github.com/Palakis/obs-websocket
-      cd ${SNAPCRAFT_PART_SRC}/plugins/
-      git clone --recursive https://github.com/Palakis/obs-websocket.git --branch 4.7.0
-      echo "add_subdirectory(obs-websocket)" >> CMakeLists.txt
-
       # Spectralizer - https://github.com/univrsal/spectralizer
       cd ${SNAPCRAFT_PART_SRC}/plugins/
       git clone --recursive https://github.com/univrsal/spectralizer.git --branch v1.2
@@ -476,9 +471,6 @@ parts:
       - libnss3-dev
       - libnspr4-dev
       - libxtst-dev
-      # Required by obs-websocket
-      - libasio-dev
-      - libwebsocketpp-dev
       # Required by Spectralizer
       - libfftw3-dev
       # Required by StreamFX
@@ -594,8 +586,21 @@ parts:
         cp ${SNAPCRAFT_PART_INSTALL}/usr/lib/obs-plugins/obs-vintage-filter.so ${SNAPCRAFT_PRIME}/usr/obs-plugins/32bit/
       fi
       mkdir -p ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/obs-vintage-filter/locale
-      mv -v ${SNAPCRAFT_PART_INSTALL}/usr/share/obs/obs-plugins/obs-vintage-filter/*.effect ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/obs-vintage-filter/
-      mv -v ${SNAPCRAFT_PART_INSTALL}/usr/share/obs/obs-plugins/obs-vintage-filter/locale/*.ini ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/obs-vintage-filter/locale/
+  obs-websocket:
+    plugin: cmake
+    after: [ obs ]
+    source: https://github.com/Palakis/obs-websocket.git
+    source-tag: '4.7.0'
+    configflags:
+      - -DCMAKE_C_COMPILER=gcc-8
+      - -DCMAKE_CXX_COMPILER=g++-8
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DLIBOBS_INCLUDE_DIR=$SNAPCRAFT_STAGE/usr/include/obs/
+    build-packages:
+      - libasio-dev
+      - libwebsocketpp-dev
+    prime:
+      - -usr/lib/$SNAPCRAFT_ARCH_TRIPLET/obs-plugins/obs-websocket.so
 
   launcher:
     after:  [ obs ]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -553,15 +553,13 @@ parts:
     after: [ obs ]
     source: https://github.com/admshao/obs-transition-matrix.git
     source-tag: 'v1.0'
-    configflags: ["-DCMAKE_INSTALL_PREFIX=/usr", "-DLIBOBS_LIB=$SNAPCRAFT_STAGE/usr/lib/$SNAPCRAFT_ARCH_TRIPLET", "-DCMAKE_CXX_COMPILER=g++-8", "-DCMAKE_C_COMPILER=gcc-8"]
-    override-prime: |
-      if echo __SIZEOF_POINTER__ | cpp -E - - | grep '^8$' >/dev/null; then
-        cp ${SNAPCRAFT_PART_INSTALL}/usr/lib/obs-plugins/obs-transition-matrix.so ${SNAPCRAFT_PRIME}/usr/obs-plugins/64bit/
-      else
-        cp ${SNAPCRAFT_PART_INSTALL}/usr/lib/obs-plugins/obs-transition-matrix.so ${SNAPCRAFT_PRIME}/usr/obs-plugins/32bit/
-      fi
-      mkdir -p ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/obs-transition-matrix/locale
-      mv -v ${SNAPCRAFT_PART_INSTALL}/usr/share/obs/obs-plugins/obs-transition-matrix/locale/*.ini ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/obs-transition-matrix/locale/
+    configflags:
+      - -DCMAKE_C_COMPILER=gcc-8
+      - -DCMAKE_CXX_COMPILER=g++-8
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DLIBOBS_INCLUDE_DIR=$SNAPCRAFT_STAGE/usr/include/obs/
+      - -DLIBOBS_LIB=$SNAPCRAFT_STAGE/usr/lib/
 
   obs-dvd-screensaver:
     plugin: cmake

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -621,5 +621,5 @@ parts:
         rm -rf ${SNAPCRAFT_PRIME}/${CRUFT}
       done
       find ${SNAPCRAFT_PRIME}/usr/share/doc/ -type f -not -name 'copyright' -delete
-      rm -v ${SNAPCRAFT_PRIME}/usr/share/doc/*/changelog.Debian.gz
+      rm -v ${SNAPCRAFT_PRIME}/usr/share/doc/*/changelog.Debian.gz || true
       find ${SNAPCRAFT_PRIME}/usr/share -type d -empty -delete

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -578,14 +578,14 @@ parts:
     after: [ obs ]
     source: https://github.com/cg2121/obs-vintage-filter.git
     source-tag: 'v0.1'
-    configflags: ["-DCMAKE_INSTALL_PREFIX=/usr", "-DLIBOBS_LIB=$SNAPCRAFT_STAGE/usr/lib/$SNAPCRAFT_ARCH_TRIPLET", "-DCMAKE_CXX_COMPILER=g++-8", "-DCMAKE_C_COMPILER=gcc-8"]
-    override-prime: |
-      if echo __SIZEOF_POINTER__ | cpp -E - - | grep '^8$' >/dev/null; then
-        cp ${SNAPCRAFT_PART_INSTALL}/usr/lib/obs-plugins/obs-vintage-filter.so ${SNAPCRAFT_PRIME}/usr/obs-plugins/64bit/
-      else
-        cp ${SNAPCRAFT_PART_INSTALL}/usr/lib/obs-plugins/obs-vintage-filter.so ${SNAPCRAFT_PRIME}/usr/obs-plugins/32bit/
-      fi
-      mkdir -p ${SNAPCRAFT_PRIME}/usr/data/obs-plugins/obs-vintage-filter/locale
+    configflags:
+      - -DCMAKE_C_COMPILER=gcc-8
+      - -DCMAKE_CXX_COMPILER=g++-8
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DLIBOBS_INCLUDE_DIR=$SNAPCRAFT_STAGE/usr/include/obs/
+      - -DLIBOBS_LIB=$SNAPCRAFT_STAGE/usr/lib/
+
   obs-websocket:
     plugin: cmake
     after: [ obs ]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -367,6 +367,11 @@ parts:
       git clone --recursive https://github.com/WarmUpTill/SceneSwitcher.git --branch 1.5
       echo "add_subdirectory(SceneSwitcher)" >> CMakeLists.txt
 
+      # StreamFX - https://github.com/Xaymar/obs-StreamFX
+      cd ${SNAPCRAFT_PART_SRC}/UI/frontend-plugins/
+      git submodule add https://github.com/Xaymar/obs-StreamFX.git streamfx --branch 0.8.0b3
+      echo "add_subdirectory(streamfx)" >> CMakeLists.txt
+
       # Source Switcher - https://github.com/exeldro/obs-source-switcher
       cd ${SNAPCRAFT_PART_SRC}/plugins/
       git clone --recursive https://github.com/exeldro/obs-source-switcher.git source-switcher
@@ -403,11 +408,6 @@ parts:
       cd ${SNAPCRAFT_PART_SRC}/plugins/
       git clone --recursive https://github.com/univrsal/scrab.git --branch v1.1
       echo "add_subdirectory(scrab)" >> CMakeLists.txt
-
-      # StreamFX - https://github.com/Xaymar/obs-StreamFX
-      cd ${SNAPCRAFT_PART_SRC}/UI/frontend-plugins/
-      git submodule add https://github.com/Xaymar/obs-StreamFX.git streamfx --branch 0.8.0b3
-      echo "add_subdirectory(streamfx)" >> CMakeLists.txt
 
       # Input Overlay - https://github.com/univrsal/input-overlay
       cd ${SNAPCRAFT_PART_SRC}/plugins/


### PR DESCRIPTION
This pull request changes the OBS build, and associated parts, to use `UNIX_STRUCTURE=1`.

In addition GCC 8 is used for all builds and parts using the `cmake` Snapcraft plugin use `-DCMAKE_BUILD_TYPE=Release` which optimises the resulting binaries for size and speed; this makes the snap smaller.