### PR TITLE
Update to OBS Studio 27.0.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -577,7 +577,7 @@ parts:
       - -DENABLE_WAYLAND=TRUE
       - -DWITH_RTMPS=TRUE
     source: https://github.com/obsproject/obs-studio.git
-    source-tag: '27.0.0-rc6'
+    source-tag: '27.0.0'
     parse-info: [usr/share/metainfo/com.obsproject.Studio.appdata.xml]
     override-pull: |
       snapcraftctl pull


### PR DESCRIPTION
I am no longer able to commit to this repository. Please consider re-instating me as someone who can commit directly.

    remote: error: At least 1 approving review is required by reviewers with write access.

This pull request bumps the version number the final release of OBS Studio 27.0.0.