### PR TITLE
Update OBS Studio to 27.0.1 and fix some bugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -619,7 +619,7 @@ parts:
       git clone --recursive https://github.com/exeldro/obs-gradient-source.git ${SNAPCRAFT_PART_SRC}/plugins/obs-gradient-source
       echo "add_subdirectory(obs-gradient-source)" >> ${SNAPCRAFT_PART_SRC}/plugins/CMakeLists.txt
 
-      git clone --recursive https://github.com/exeldro/obs-move-transition.git ${SNAPCRAFT_PART_SRC}/plugins/obs-move-transition --branch 2.4.1
+      git clone --recursive https://github.com/exeldro/obs-move-transition.git ${SNAPCRAFT_PART_SRC}/plugins/obs-move-transition --branch 2.4.3
       echo "add_subdirectory(obs-move-transition)" >> ${SNAPCRAFT_PART_SRC}/plugins/CMakeLists.txt
 
       git clone --recursive https://github.com/exeldro/obs-recursion-effect.git ${SNAPCRAFT_PART_SRC}/plugins/obs-recursion-effect

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -628,7 +628,7 @@ parts:
       git clone --recursive https://github.com/exeldro/obs-replay-source.git ${SNAPCRAFT_PART_SRC}/plugins/obs-replay-source
       echo "add_subdirectory(obs-replay-source)" >> ${SNAPCRAFT_PART_SRC}/plugins/CMakeLists.txt
 
-      git clone --recursive https://github.com/iamscottxu/obs-rtspserver.git ${SNAPCRAFT_PART_SRC}/plugins/obs-rtspserver --branch v2.0.3
+      git clone --recursive https://github.com/iamscottxu/obs-rtspserver.git ${SNAPCRAFT_PART_SRC}/plugins/obs-rtspserver --branch v2.1.0
       echo "add_subdirectory(obs-rtspserver)" >> ${SNAPCRAFT_PART_SRC}/plugins/CMakeLists.txt
 
       git clone --recursive https://github.com/WarmUpTill/SceneSwitcher.git ${SNAPCRAFT_PART_SRC}/UI/frontend-plugins/SceneSwitcher --branch 1.15.2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -577,7 +577,7 @@ parts:
       - -DENABLE_WAYLAND=TRUE
       - -DWITH_RTMPS=TRUE
     source: https://github.com/obsproject/obs-studio.git
-    source-tag: '27.0.0'
+    source-tag: '27.0.1'
     parse-info: [usr/share/metainfo/com.obsproject.Studio.appdata.xml]
     override-pull: |
       snapcraftctl pull

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -928,7 +928,7 @@ parts:
     plugin: meson
     after: [ obs ]
     source: https://github.com/fzwoch/obs-gstreamer.git
-    source-tag: 'v0.3.1'
+    source-tag: 'v0.3.2'
     meson-parameters:
       - --prefix=/usr
       - --buildtype=release

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1079,7 +1079,7 @@ parts:
     plugin: cmake
     after: [ obs ]
     source: https://github.com/Palakis/obs-websocket.git
-    source-branch: '4.9.0'
+    source-branch: '4.9.1'
     build-environment:
       - Qt5_DIR: $SNAPCRAFT_STAGE/opt/qt515
     cmake-parameters:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -631,7 +631,7 @@ parts:
       git clone --recursive https://github.com/iamscottxu/obs-rtspserver.git ${SNAPCRAFT_PART_SRC}/plugins/obs-rtspserver --branch v2.0.3
       echo "add_subdirectory(obs-rtspserver)" >> ${SNAPCRAFT_PART_SRC}/plugins/CMakeLists.txt
 
-      git clone --recursive https://github.com/WarmUpTill/SceneSwitcher.git ${SNAPCRAFT_PART_SRC}/UI/frontend-plugins/SceneSwitcher --branch 1.12
+      git clone --recursive https://github.com/WarmUpTill/SceneSwitcher.git ${SNAPCRAFT_PART_SRC}/UI/frontend-plugins/SceneSwitcher --branch 1.15.2
       echo "add_subdirectory(SceneSwitcher)" >> ${SNAPCRAFT_PART_SRC}/UI/frontend-plugins/CMakeLists.txt
 
       git clone --recursive https://github.com/exeldro/obs-source-copy.git ${SNAPCRAFT_PART_SRC}/UI/frontend-plugins/obs-source-copy


### PR DESCRIPTION
The pull request updates OBS to 27.0.1, updates and number of plugins to current versions and fixes OBS starting when Wayland is the current display server.