### PR TITLE
Add background removal plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The snap of OBS studio comes pre-loaded with some additional features and plugin
   * Supports **nvenc (NVIDIA) and VA-API (AMD & Intel) accelerated video encoding**.
   * **[Advanced Scene Switcher](https://github.com/WarmUpTill/SceneSwitcher)** plugin; an automated scene switcher.
   * **[Audio Pan](https://github.com/norihiro/obs-audio-pan-filter)** plugin; control stereo pan of audio source.
+  * **[Background Removal](https://github.com/royshil/obs-backgroundremoval)** plugin; remove the background using a neural network.
   * **[Browser](https://github.com/obsproject/obs-browser)** plugin; CEF-based OBS Studio browser plugin.
   * **[Directory Watch Media](https://github.com/exeldro/obs-dir-watch-media)** plugin; filter you can add to media source to load the oldest or newest file in a directory.
   * **[DVD Screensaver](https://github.com/univrsal/dvds3)** plugin; a DVD screen saver source type.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1111,6 +1111,43 @@ parts:
     prime:
       - -usr/lib/$SNAPCRAFT_ARCH_TRIPLET/obs-plugins
 
+  onnxruntime:
+    plugin: dump
+    source: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
+    organize:
+      include/*.h: usr/include/
+      lib/*.so*: usr/lib/
+    prime:
+      - usr/lib
+
+  obs-backgroundremoval:
+    plugin: cmake
+    after: [ obs, onnxruntime ]
+    source: https://github.com/royshil/obs-backgroundremoval.git
+    build-packages:
+      - libopencv-dev
+      - language-pack-en
+      - build-essential
+    stage-packages:
+      - libopencv-core4.2
+      - libopencv-highgui4.2
+    override-build: |
+      cd "${SNAPCRAFT_PART_SRC}"
+      mkdir -p "${SNAPCRAFT_PART_SRC}/build"
+      cd "${SNAPCRAFT_PART_SRC}/build"
+      cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_MODULE_LINKER_FLAGS=-L"${SNAPCRAFT_STAGE}"/usr/lib/ -lonnxruntime \
+        -DLIBOBS_INCLUDE_DIR="${SNAPCRAFT_STAGE}"/usr/include/obs/ \
+        -DOnnxruntime_INCLUDE_DIR="${SNAPCRAFT_STAGE}"/usr/include/ \
+        -DOnnxruntime_LIBRARIES="${SNAPCRAFT_STAGE}"/usr/lib/libonnxruntime.so \
+        "${SNAPCRAFT_PART_SRC}"
+      make -j $(nproc)
+      make install DESTDIR="${SNAPCRAFT_PART_INSTALL}"
+    organize:
+      usr/lib/$SNAPCRAFT_ARCH_TRIPLET/obs-plugins/obs-backgroundremoval.so: usr/lib/obs-plugins/
+
   obs-wrapper:
     plugin: dump
     after:


### PR DESCRIPTION
This pull request adds the obs-backgroundremoval plugin and also libonnxruntime, which is used as its dependency.

I've been using this plugin lately and it has worked very well. I created the new snapcraft parts using the instructions provided by the author in the git repo.