### PR TITLE
Add LookingGlass plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The snap of OBS studio comes pre-loaded with some additional features and plugin
   * **[Game Capture](https://github.com/nowrep/obs-vkcapture)** plugin; Vulkan/OpenGL game capture.
   * **[Gradient Source](https://github.com/exeldro/obs-gradient-source)** plugin; adding gradients as a Soource.
   * **[GStreamer](https://github.com/fzwoch/obs-gstreamer)** plugins; feed GStreamer launch pipelines into OBS Studio and use GStreamer encoder elements.
+  * **[Looking Glass](https://github.com/gnif/LookingGlass/)** plugin; feed VGA PCI Passthrough frame relay buffer directly into OBS Studio as a video source rather than Screen/Window Capture source
   * **[Move Transition](https://github.com/exeldro/obs-move-transition)** plugin; move source to a new position during scene transition.
   * **[NDI](https://github.com/Palakis/obs-ndi)** plugin; Network A/V via NewTek's NDI.
   * **[NvFBC](https://gitlab.com/fzwoch/obs-nvfbc)** plugin; screen capture via NVIDIA FBC API. Requires [NvFBC patches for Nvidia drivers](https://github.com/keylase/nvidia-patch) for consumer grade GPUs.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -963,6 +963,22 @@ parts:
     organize:
       usr/lib/$SNAPCRAFT_ARCH_TRIPLET/obs-plugins/obs-gstreamer.so: usr/lib/obs-plugins/
 
+  liblooking-glass-obs:
+    plugin: cmake
+    after: [ obs ]
+    source: https://github.com/gnif/LookingGlass.git
+    source-branch: 'Release/B4'
+    build-packages:
+      - binutils-dev
+    override-build: |
+      mkdir -p $SNAPCRAFT_PART_SRC/obs/build
+      cd $SNAPCRAFT_PART_SRC/obs/build
+      cmake $SNAPCRAFT_PART_SRC/obs
+      make -j $(nproc)
+      make install DESTDIR=$SNAPCRAFT_PART_INSTALL
+    organize:
+      usr/local/share/obs/obs-plugins/looking-glass-obs/bin/64bit: usr/lib/obs-plugins/
+
   obs-ndi:
     plugin: cmake
     after:


### PR DESCRIPTION
This plugin allows directly feeding the Looking Glass frame buffer into OBS. This frame buffer is used for virtual machines with PCI passthrough to display on the host machine.

This requires the [Looking Glass](https://github.com/gnif/LookingGlass) client and host installed on the host and VM guest, respectively. I've tested this with the master branch (as that is what I'm using for client/host on my machine), but I've added the plugin to the snap using the latest stable release (`Release/B4`)