### PR TITLE
Update README.md to remove old reference to edge for Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The snap of OBS studio comes pre-loaded with some additional features and plugin
 ## Wayland
 
 Screen and Window capture in a Wayland session is supported in OBS 27.0.0 or
-newer (currently only available in the edge channel).
+newer.
 
 ## Removable Storage
 


### PR DESCRIPTION
The stable channel is currently shipping a variant of 27.1.3 so this should be in all channels now, no ?