### PR TITLE
Pull latest OBS portable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
     source: snap/local
   obs:
     plugin: dump
-    source: https://github.com/wimpysworld/obs-studio-portable/releases/download/r23316/obs-portable-30.0.0-r23316-ubuntu-22.04.tar.bz2
+    source: https://github.com/wimpysworld/obs-studio-portable/releases/download/r23319/obs-portable-30.0.0-r23319-ubuntu-22.04.tar.bz2
     stage-packages:
       - lib32gcc-s1 
       - lib32stdc++6 


### PR DESCRIPTION
Has fixes for a couple of plugins:

* feat: update NDI and VA-API plugins by @flexiondotorg in https://github.com/wimpysworld/obs-studio-portable/pull/40