### PR TITLE
Update to latest OBS portable build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
     source: snap/local
   obs:
     plugin: dump
-    source: https://github.com/wimpysworld/obs-studio-portable/releases/download/r23319/obs-portable-30.0.0-r23319-ubuntu-22.04.tar.bz2
+    source: https://github.com/wimpysworld/obs-studio-portable/releases/download/r23344/obs-portable-30.0.0-r23344-ubuntu-22.04.tar.bz2
     stage-packages:
       - lib32gcc-s1 
       - lib32stdc++6 


### PR DESCRIPTION
* feat: update url-source to 0.2.5 by @flexiondotorg in https://github.com/wimpysworld/obs-studio-portable/pull/45
* feat: update 3d effect to 0.1.0 by @flexiondotorg in https://github.com/wimpysworld/obs-studio-portable/pull/46
* fix: correct LD_LIBRARY_PATH and override environment for running in distrobox by @flexiondotorg in https://github.com/wimpysworld/obs-studio-portable/pull/47