### PR TITLE
chore: update to OBS 30 r23356

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
     source: snap/local
   obs:
     plugin: dump
-    source: https://github.com/wimpysworld/obs-studio-portable/releases/download/r23344/obs-portable-30.0.0-r23344-ubuntu-22.04.tar.bz2
+    source: https://github.com/wimpysworld/obs-studio-portable/releases/download/r23356/obs-portable-30.0.0-r23356-ubuntu-22.04.tar.bz2
     stage-packages:
       - lib32gcc-s1 
       - lib32stdc++6 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
     source: snap/local
   obs:
     plugin: dump
-    source: https://github.com/wimpysworld/obs-studio-portable/releases/download/r23356/obs-portable-30.0.0-r23356-ubuntu-22.04.tar.bz2
+    source: https://github.com/wimpysworld/obs-studio-portable/releases/download/r23356/obs-portable-30.0.2-r23356-ubuntu-22.04.tar.bz2
     stage-packages:
       - lib32gcc-s1 
       - lib32stdc++6 


### PR DESCRIPTION
## What's Changed

* feat: update scene switcher to 1.24.2 by @flexiondotorg in [#49](https://github.com/wimpysworld/obs-studio-portable/pull/49)
* feat: update to composite blur 1.1.0 by @flexiondotorg in [#50](https://github.com/wimpysworld/obs-studio-portable/pull/50)
* feat: update move transition to 2.9.7 by @flexiondotorg in [#54](https://github.com/wimpysworld/obs-studio-portable/pull/54)
* feat: update advanced masks to 1.0.1 by @flexiondotorg in [#51](https://github.com/wimpysworld/obs-studio-portable/pull/51)
* feat: update OBS Studio to 30.0.2 by @flexiondotorg in [#55](https://github.com/wimpysworld/obs-studio-portable/pull/55)
* feat: update local vocal to 0.0.8 by @flexiondotorg in [#53](https://github.com/wimpysworld/obs-studio-portable/pull/53)
* feat: update background removal to 1.1.8 by @flexiondotorg in [#52](https://github.com/wimpysworld/obs-studio-portable/pull/52)

Full Changelog: [r23344...r23356](https://github.com/wimpysworld/obs-studio-portable/compare/r23344...r23356)