### PR TITLE
fix: include intel -dev graphics packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,9 +58,7 @@ parts:
       - intel-ocloc
       - intel-opencl-icd
       - libigc2
-      - libigc-dev
       - libigc-tools
-      - libigdfcl-dev
       - libigdfcl2
       - libigdgmm12
       - libmfx1
@@ -73,6 +71,13 @@ parts:
       - libze1
       - libze-intel-gpu1
       - ocl-icd-libopencl1
+      # Note, these -dev packages deliver development sym links that
+      # may be dynamically loaded by Intel compute runtime drivers.
+      - libigc-dev
+      - libigdfcl-dev
+    prime:
+      - -usr/include
+      - -usr/share
 
 apps:
   obs-studio:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,7 +58,9 @@ parts:
       - intel-ocloc
       - intel-opencl-icd
       - libigc2
+      - libigc-dev
       - libigc-tools
+      - libigdfcl-dev
       - libigdfcl2
       - libigdgmm12
       - libmfx1


### PR DESCRIPTION
Without these `-dev` packages the OpenVINO plugins are not running properly on GPUs and NPUs, most likely because they deliver .so sym links that are needed by OBS at runtime.