### PR TITLE
Adding the HOME variable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,6 +92,7 @@ apps:
       OBS_PLUGINS_PATH: $SNAP_DATA/obs-plugins/plugins/
       OBS_PLUGINS_DATA_PATH: $SNAP_DATA/obs-plugins/data/
       OCL_ICD_VENDORS: $SNAP/etc/OpenCL/vendors
+      HOME: $SNAP_USER_COMMON
     plugs:
       - alsa
       - audio-playback


### PR DESCRIPTION
OBS Studio uses the $HOME folder as the default folder for creating video files.

In the Snap version, the $HOME folder used is $SNAP_USER_DATA, which causes video files to be duplicated when updating OBS Studio.

This change is to use the $SNAP_USER_COMMON folder as the $HOME folder; from what I've seen, this will only affect new installations.