### PR TITLE
fix: avoid stale user settings by pointing config dir to `$SNAP_USER_COMMON`

### DIFF
--- a/snap/local/obs-wrapper
+++ b/snap/local/obs-wrapper
@@ -19,6 +19,11 @@ elif [ "${XDG_SESSION_TYPE}" == "x11" ]; then
   export QT_QPA_PLATFORM="xcb"
 fi
 
+# The gnome extension sets XDG_CONFIG_HOME=$SNAP_USER_DATA/.config (revision-specific)
+# in the command-chain, which OBS's os_get_config_path checks before $HOME/.config.
+# Override it here so the OBS settings survive snap refreshes
+export XDG_CONFIG_HOME="$SNAP_USER_COMMON/.config"
+
 unset SESSION_MANAGER
 
 # obs is run with --multi because it tries to bind a UNIX socket as lock


### PR DESCRIPTION
The gnome extension [sets `$XDG_CONFIG_HOME=$SNAP_USER_DATA/.config`](https://github.com/canonical/snapcraft/blob/ebecfd613c84d71701aecd5a58567dc7647a55a6/extensions/desktop/common/init#L45), which OBS's `os_get_config_path` [checks](https://github.com/obsproject/obs-studio/blob/0052d024fd6a5ff1aa04c76cbdffd3085a5dfacc/libobs/util/platform-nix.c#L227-L235) before `$HOME/.config`.

With this change, OBS config will be stable across snap refreshes and immune to the stale `[Locations]`. Hence fix gh-252.

⚠️ There's a decision here though. First time users upgrade the snap to the revision including these changes, their previous config will be ignored once again. We can either (a) tell users that there's a manual step involved, or (b)  complicate the logic here to automatically try to read the config from `$SNAP_USER_DATA` of the previous revision.